### PR TITLE
Return an empty object on a 404 error rather than retrying forever

### DIFF
--- a/custom_components/grohe_sense/__init__.py
+++ b/custom_components/grohe_sense/__init__.py
@@ -171,6 +171,8 @@ class OauthSession:
                             _LOGGER.error('Grohe sense refresh token is invalid (or expired), please update your configuration with a new refresh token')
                             self._refresh_token = get_token(self._session, self._username, self._password)
                             token = await self.token(token)
+                    elif response.status == 404:
+                        return []
                     else:
                         _LOGGER.debug('Request to %s returned status %d, %s', url, response.status, await response.text())
             except OauthException as oe:


### PR DESCRIPTION
When a room is registered but doesn't have appliances, the API returns a 404 error code.

This used to cause the addon to retry forever and never start.

A 404 error is not recoverable, so retrying is unlikely to be useful anyways.